### PR TITLE
Task 4: add DynamoDB and integrate it with endpoints

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <includedPredefinedLibrary name="Node.js Core" />
+  </component>
+</project>

--- a/populateDb/index.js
+++ b/populateDb/index.js
@@ -1,0 +1,36 @@
+const { DynamoDBClient, BatchWriteItemCommand } = require( "@aws-sdk/client-dynamodb");
+const ProductsSource = require("../productService/products.json");
+
+(async () => {
+  const client = new DynamoDBClient({ region: "eu-west-1" });
+  const batchCreateParams = {RequestItems: {}};
+  batchCreateParams.RequestItems.cloudX_products = ProductsSource.map(x => ({
+    PutRequest: {
+      Item: {
+        id: { S: x.id },
+        description: { S: x.description },
+        price: { N: x.price.toString() },
+        title: { S: x.title },
+      },
+    },
+  }));
+
+  batchCreateParams.RequestItems.cloudX_stocks = ProductsSource.map(x => ({
+    PutRequest: {
+      Item: {
+        product_id: { S: x.id },
+        count: { N: x.count.toString() },
+      },
+    },
+  }))
+
+  const command = new BatchWriteItemCommand(batchCreateParams);
+
+  try {
+    const results = await client.send(command);
+    console.log("Success, items inserted", results);
+    return results;
+  } catch (err) {
+    console.error(err);
+  }
+})();

--- a/populateDb/package-lock.json
+++ b/populateDb/package-lock.json
@@ -1,0 +1,1198 @@
+{
+  "name": "cloudX-dynamodb-population",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.222.0.tgz",
+      "integrity": "sha512-Ric2vJQEWrzz915wBeZlYLWAnIsnywOcZpzroPVTY/TNKRvM0GcSPVuD9vv1lOwybVnDHsipukzwQBAZXkNWVA==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "requires": {
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-dynamodb": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.223.0.tgz",
+      "integrity": "sha512-LDSz7hDrftllZX8JZQE84BSbqrp41WT7+9KUv6GQmnB5wy2kAACK3mkPlSXXso5IB4SUuNR9OFontPXFzX/Zhw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.223.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.222.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.223.0.tgz",
+      "integrity": "sha512-hIQfiseFXf04jz14iyQhfV9eRz9XgiMihl9oQhKs3CpL7bFGkhCkCIwbqUrsheqcD1O2wcOSKTAt6QdYbDyhzg==",
+      "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.223.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/eventstream-serde-browser": "3.222.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.222.0",
+        "@aws-sdk/eventstream-serde-node": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-blob-browser": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/hash-stream-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/md5-js": "3.222.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-expect-continue": "3.222.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-location-constraint": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-s3": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-ssec": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4-multi-region": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-stream-browser": "3.222.0",
+        "@aws-sdk/util-stream-node": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.222.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.223.0.tgz",
+      "integrity": "sha512-1gVmZ7XypZEWUeKnvjS/cZSL/cM1riOGrhp+dr+np58ZT5zSrpWAAeKE5+ftzC/vn770vnD5piLGdAZwg/Jf1g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.223.0.tgz",
+      "integrity": "sha512-MeXm6expqpBwwN5GWm8QedAxWGv1jpdxae5oSqsrfRSHFVcHVxWWQzx9/GMBpKqGLtXVmisex2vckBQa1MhybQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.223.0.tgz",
+      "integrity": "sha512-RYGx6SOT38MfX4Dm8lyEwZ/bEqhl3TZyGFqtFHGTEEgyqPkuqiZPfSSWNmsaf6HAVYKObp7kJUX6w8EeEw332w==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-sts": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.222.0.tgz",
+      "integrity": "sha512-rG/Yh0R+GQe86ofEb24QAjQ19tHb4HMCyCuMZUZCsIdgNmUfcaH21Ug5s7pJrAfEy/F2gwxs+VfBeXKjT0MqSQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.222.0.tgz",
+      "integrity": "sha512-xV6cmJ9zMi8nWySqBv1ze/EFlzXEfazu3i/T/5MpOufPvuGpXTQ3/PDEbC6mKBtvomoQ0fonc/cZrix7YcJV0Q==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.222.0.tgz",
+      "integrity": "sha512-n090ouw5AFhb0EfzRElUTmqCNOQ1zjlxau30oVM7+qKtXH85hEGMQOoRQAl9ch/pXcbjKLh1mbUhmonR97/Kvw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.223.0.tgz",
+      "integrity": "sha512-+jB0XIqAw7Cni1uqPV6SMQl7FlpUVELdHVnR+DYL3WOV4MJ4amTu9MAXrpvbEXbK3+7eFQ2/tDe+7i8qGXZFTw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.223.0.tgz",
+      "integrity": "sha512-mvY96yX4xQ9/Aujr0HqMXhdToiEKg7fFUoN+NgV3yB/hj2q1Ry3j8WbiIfAcBvFLjNwHT7ae/8nVRHYYlNeXFw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-ini": "3.223.0",
+        "@aws-sdk/credential-provider-process": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.222.0.tgz",
+      "integrity": "sha512-IgEk8Tne1b2v2k/wVjuddKi+HEAFJWUoEcvLCnYRdlVX5l+Nnatw8vGYb+gTi9X7nKNqEGfMbifKCFoePKjC0Q==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.223.0.tgz",
+      "integrity": "sha512-sRxH6fhLYME+EIiHRqIzkUgPaAvc5+dV8+09jEZ1yBjum9AQycipXrbbDRNLXWJZJZTA/BsHfUpAScFOjyZf7A==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/token-providers": "3.223.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.222.0.tgz",
+      "integrity": "sha512-dImqTEWt38nVcDe/wQqHWJ+R2zyNqVKwejfslgbH2YilUnDU43xq2KJhNe4s+YhCB6tHOTkbNnpZo7vPV5Zxog==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/endpoint-cache": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
+      "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+      "requires": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.222.0.tgz",
+      "integrity": "sha512-sxLpo3NYrvj8CnTkpLsb2uXvUU8jnAG5q22HIBxBrpeFzgvUA9uIfPD7yPZhe4+/C7v+ER19ysXetKjiAOrQMA==",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.222.0.tgz",
+      "integrity": "sha512-owwgmkpuLM7UtNPRZjvCOp5fo6MKY8avygQA0VMsbQSCq1DJFpmDsk7yTRB+n7jQuoDGn8uVxER3S0oS/Y/xVQ==",
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.222.0.tgz",
+      "integrity": "sha512-zb8vMSbBEjUrHKpA2bZdAqfYp8oCsWgeBPOt0XJx+y6lzy67zyADs97Grl+lyZAoswao/zc2sxgm9yqcMDt7lQ==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.222.0.tgz",
+      "integrity": "sha512-rfDrTxcsYL0ZKc5MnoqbDTa0oQFiK7qTJOnQ7sASooexqoKTn3wVq68J7TZddbImmH/ENpkU+O0hcGuiwE9Ucg==",
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.222.0.tgz",
+      "integrity": "sha512-+/Fc7+ZPuD6SwphYcuLJ/GU0RmVzG/M0dUYs1JL/JQJ8dkJ0AlH1fH3L5Fhm2RO/ACkE28kXAuyZ40TLeRLRNA==",
+      "requires": {
+        "@aws-sdk/eventstream-codec": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.222.0.tgz",
+      "integrity": "sha512-0PWnOp47mNfwBFEZhuBpz5A+66jbvb2ySidnM5vWHRxu5yN7rCJEdEMSJKDzR6nH3GLZ9dHoOxTzQy21NoDTtA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.222.0.tgz",
+      "integrity": "sha512-Z6y3JZPNp+os9vZdvsNkM6mIjDzeZNr9MYkQslANhGZ9WgQrzuI7xZN6XAyR83OGRCrDCorZdX+nnl5mzY1VwQ==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.222.0.tgz",
+      "integrity": "sha512-Fw0acblG0LQT9tfD2/4j98QHNq+Crotig/M1/zPDcVoGb8OBHd2442zpeA0fYYjGnGGhy9psRHdJrjZGj1vDUw==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.222.0.tgz",
+      "integrity": "sha512-PO/N0PsgJjRiH9WKSOnGjDP9tWNjwSvUezicT8ItWgkk7npd278MAe7G692TLACgf6sJr2jGQbs6xzZHq0/3Zg==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.222.0.tgz",
+      "integrity": "sha512-tWJWWTcL7DrhFiDmPBvLaw2lopHJMsF4Uj52yIQJskwd2IeBOxjl30zLo/oidmk73IFUB7TCObc85zJrtt/KcQ==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.222.0.tgz",
+      "integrity": "sha512-LI44dy+ECCL+vsIYJ/Ot4rNOl3Vpa4Nv8zxireKcQGmn547Cb6i3n/bEi/DkcfgHv6R84qOtOXsxt/ILuWNQ/g==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.222.0.tgz",
+      "integrity": "sha512-TP4mjEWsQ/JsACAFDUlltl/0sAe5dxqdhBDAPO6LHRHvROz2oYVjZwvcaK4F9x8QLWh09H0Sw501SndFK2+o3w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.222.0.tgz",
+      "integrity": "sha512-Wlah+nrPhcq5qcwHiK1ymVRAvcKjV2py2RXhJsNZWgYwphdt5RHaZHPDKoodI27alrDJVyBBQWGzIm/Ag1bypQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.222.0.tgz",
+      "integrity": "sha512-e1bM+CvuUWmBdydQpV5sF8cxZrXQ++0G5s1M7pLimKdWXQvCQ1ZEwA3LLi2IWomXmS9a3BaH3iKAf87RTWjIXw==",
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.222.0.tgz",
+      "integrity": "sha512-5PuTWAYY1ER5xU6n1y9FmfAKh1/6a7/XcYzwabWj1eL8nCKsPvCzQnEADR7cL+2AbPXwgcLK3LQgw8ywY8JDeg==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/endpoint-cache": "3.208.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.222.0.tgz",
+      "integrity": "sha512-/nTCLXrau8jEyehsD7QM49gJQ6kmzQGw7plPDJzdFakfAwb2b/jLJ/Hj/ZSaaLWWEXAtZBiPzVXUJltPDoXv5g==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.222.0.tgz",
+      "integrity": "sha512-P900+KLMUg0eOf75FK/wH/Gjz3rkNtB6iBfAG2Xg4DY5+78qh40deG0y0ZvtkHQP8YOqjLF3QMbEA90YXo4x9Q==",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.222.0.tgz",
+      "integrity": "sha512-R4STwHkWgdxMRqOy6riYfXepsQURR5YhK6psPFZHkBYByIRc9JxJdLA0qZcfLRriQIAGmqEO2WWsqRmr8nkbBw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.222.0.tgz",
+      "integrity": "sha512-srrAkOHuvpXeaMG9a6kvfYrhzFFX/plBaZATy8iW6ethgvG1qdPeFj4ZVS9Eisx+13NbGFtydc1WkBZfx2nUWg==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.222.0.tgz",
+      "integrity": "sha512-eAxGCcNXl1APMOFbkUaAC6pNBPUbajyGqsDf6GLdlrYHrMVAtJdYd988ov6C52h7k6iDZ+OPHwv8dwUz+PRfpw==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.222.0.tgz",
+      "integrity": "sha512-4JRVs7y5JDXXjc5fkz0FCZJt/0HTP2vh3QyZsWRbCYesw2cWVqQlp/fUXp8w5KGqm5nYkTF4e5SQ7Ca8powJNA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.222.0.tgz",
+      "integrity": "sha512-8FZpGuJDtntjXZ/mfJ9EdP5mYiUunQHEmk6OERk3h4XW3D/e97denwDAcBBIK8iYYGic5PoWF4KgTFJWs1YOcw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/service-error-classification": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.222.0.tgz",
+      "integrity": "sha512-GCgbzWy3Dn9+dz/ZZjS5OiJ+feighHfMt461r1zjHNUXnb2tEf5kU+P80d3WqG8er4RRQg+Ao49SatOKgPcrlA==",
+      "requires": {
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.222.0.tgz",
+      "integrity": "sha512-YbL4lTBFgqyL2Ob+dMyw/UNd5K9IOnZHHxjpwWlYKMrfT+pp2bvrr7XUbRHnxSoDsOg9bf6IyTSRVnVxP4psJg==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.222.0.tgz",
+      "integrity": "sha512-UoeLbgCJB07dX8tRByR0KzZaOwCoIyXj/SfFTuOhBUjkpKwqFCam/hofDlK3FR6kvl+xiURv57W/FtKV/9TDHg==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.222.0.tgz",
+      "integrity": "sha512-MwMw2Lz7SBOniAc0slWXt65ocqL+E956bdW+LOvBin6OgkVWaLRbWI9nOzA6B2d8b65fCGEc+N15i0UdrEf+MQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.222.0.tgz",
+      "integrity": "sha512-WThCx/+UG4gIyqx0G3QKD1RM71+adh9Jv3Sh/KiS07Jjm+pb71wW+RRzBuNyhdjwB3aoKC/YKW8eFQg6M7eaQg==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.222.0.tgz",
+      "integrity": "sha512-ASKbstAKbOBUZhFhst6/NCr11x94BDBiQn2zDs2Lvjo89n2efMeb4wEr17VCMZVeKI6ojtPFa1ZVLsH8AOn4Yw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.222.0.tgz",
+      "integrity": "sha512-fjdxCRIAhOTsI9OcEKwJp4lhsvyCSXoeYV49mO/bdG6pFyFRm3Jezx7TNVNeLTGuMHTTTvRrCTF8sgE5t17Pzw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.222.0.tgz",
+      "integrity": "sha512-hrbw90LlVa4xJJc4WiyAfaPMY/sJubSeTwuxTChLsFOavr6hSMCwLASrWmOiKRIj5hKdSfEA87n/q+DnKHlA8A==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.222.0.tgz",
+      "integrity": "sha512-k3WqxUgZzGbiCQt1HyzDGlRzq8muGIOWZs9T3HtCa5LtACvl0qlNmiwCc+C/o7GRLyC9FuWkP3lOW6MiAFQUcA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.222.0.tgz",
+      "integrity": "sha512-rEqAgQ7itmB7GB+WWLgyT7/YWJkjEBCfggxycccChWAeqg+gjpstIiGX2BjP2K/wnzwE0D91JsozSXcQIDOtNQ==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.222.0.tgz",
+      "integrity": "sha512-Zj+ytEgrOagCE7yczjdDan7W+1a0OL5DPAx69Z00NxGoBI2h0GRZD28dRYb3Pzs5/Ft4KbCedH/RUnyaYjaZxw==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.222.0.tgz",
+      "integrity": "sha512-qrNUGDyDp9yVQMnBbz1T5YBQkA/u6D5o0PPzSwfZ9azdAcBLjHOEfsBrKhxP+K92L/nilbnmY89KrjMR8+BNtw==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.222.0.tgz",
+      "integrity": "sha512-3KfkCA/753PlF5QqhGuQ7u+NOgLyiBFeV8R8ut/pfBmG8fF6l3RKrkbcu+87QpqXntRzG+RLHDqS7ryT3B2ICg==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.222.0.tgz",
+      "integrity": "sha512-Dn/WGtm+v5nney0CaYZjdOtJmdEuI8EQiQ5J3eQ3G0jjT6mr1/tCajsNpq3ZqHXiwLtydwaVvsL3AKXn+oxFVA=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.222.0.tgz",
+      "integrity": "sha512-2dowzMXjvIf5gwX5gNCwpv/TzAbbXxrId3zYJgPdEtApsa7NxyFs5MfnHt1zZI6P3YORGheRnNUK9RUYOPKHgA==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.222.0.tgz",
+      "integrity": "sha512-2qQZuKqx56b2uN2rdjdKL6u0Cvk82uTGNtIuetmySY9xPEAljSBdriaxTqNqK9Gs3M4obG22alUK4a85uwqS3g==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.222.0.tgz",
+      "integrity": "sha512-SF6Qi0KW69OzgLbA9q6AsZNFQCA+DI66SnAjW774sAE6aQyJmCbUsxETk37XodSymXzDOEDDC6QoY64HUoSoVw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.222.0.tgz",
+      "integrity": "sha512-4dnU7TvwKxVuOWduvFGClYe0EgNov5Ke1ef7O1bdKaj5MmlH6wBDgGJM4NKREBFapC2dUXkoPtwsihtYBci1Bw==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.223.0.tgz",
+      "integrity": "sha512-ik6IYiZO9tTzYPJKzUob4U9faC9We6UtVZGynEGLMWSLETM+LefSHK0elEaJaCqx2F4NLodw+t9uvllR+8YUow==",
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.222.0.tgz",
+      "integrity": "sha512-yXRYptInkfEFaOvWFxlRXsRh9jWOmQc1sZeKqjfx2UCtzNJ7ebedN0VfCz4SaDotcw9Q4JWuN66qhRMJjDx7/w=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.222.0.tgz",
+      "integrity": "sha512-1+QbVdT/phYDb5JDQRJWoZeCujkXaI5m8z3bIiPxcRRY3NPuluDGrfX3kfnFen5s9QGByLvJxWKWZS+i+iUFRg==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.222.0.tgz",
+      "integrity": "sha512-+dGsp59lrEkDmK7OO5ecMYasrTGIKacFHjqZ6aqmbn1xtcUd/o3Qe7g5YSRXMGwtZ6xhvBD+NJLkEERI7U7cMw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.222.0.tgz",
+      "integrity": "sha512-W/duYMtmCCWdzHP+yscBB6yrARgAqWpFdxgBvMSlT8TjOTrh/F+aj4NPamiNMeUfqfMFGnboYfyWRr1avkcAGQ==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.222.0.tgz",
+      "integrity": "sha512-qujJQv8lFysAr1lOlBTJhz7949NZyq5cj74Q9dR99AcAMXXeI9CQayPKH7477AnXRGOTMahZ3mV0HZ1bCJoNTw==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.222.0.tgz",
+      "integrity": "sha512-Y4BPtSa+6+qvg6OVW6RrdDx0OADfWa2Uxsxqdozpdnx2OQY0q+1diqsNgFMV+FIvdXqffE147KG7roG+/AfPeA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.222.0.tgz",
+      "integrity": "sha512-GW9Y1/pLHS7WYHHdswcDd4vaM9mzxDwewcDVujCd/L9MRbG1nA/wfCL7hAAXT1AN2GbGfbfT+jjHQqzexpKBnA==",
+      "requires": {
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.222.0.tgz",
+      "integrity": "sha512-iMwKG+RaGVAjzXDuzmMl63SnN6qVc+0VbbfaKW1eIK9Ihr5mko3GuYAFqKaECSQ+XdMNuMSVXzphveKw6t2zwg==",
+      "requires": {
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.222.0.tgz",
+      "integrity": "sha512-DREMeL0XHl4QIS2GVSHFwVH4mJZ+Dr04R3U8WfiMktXdA93j5tDMJpU3+PNaCZPeaqz2QNwrVSBWKwbwA357zQ==",
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.222.0.tgz",
+      "integrity": "sha512-BMRMrPXL/HS3dSha9vcABkoANluKjB0pH78bc659EY2WUj9wCZdbUNQpACiYx8bwm7xKSxugCkmPd6NLWXUURw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.222.0.tgz",
+      "integrity": "sha512-/07RkfxvDncsMeQ+GhigPdiSRd2v/1FJoCV4a5e9XDI1ZSMvUKm36wFqw5Bzts+AUY8f4HOPpGI9ZQeNb7u27Q==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
+    "mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "requires": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/populateDb/package.json
+++ b/populateDb/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cloudX-dynamodb-population",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.223.0",
+    "@aws-sdk/client-s3": "^3.32.0"
+  }
+}

--- a/productService/handler.js
+++ b/productService/handler.js
@@ -1,25 +1,87 @@
 'use strict';
-
-const products = require("./products.json");
+const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient();
 
 module.exports.getProductsList = async (event) => {
+  const productsData = await docClient.scan({
+    TableName : process.env.PRODUCTS_DB_NAME
+  })
+    .promise();
+
+  const stocksData = await docClient.scan({
+    TableName : process.env.STOCKS_DB_NAME
+  })
+    .promise();
+
+  const respData = productsData.Items.map(p => ({
+    ...p,
+    count: stocksData.Items.find(s => s.product_id === p.id).count
+  }))
   return {
     statusCode: 200,
     headers: {
       "content-type":"application/json",
     },
-    body: JSON.stringify(products)
+    body: JSON.stringify(respData)
   };
 };
 
 module.exports.getProductsById = async (event) => {
   const productId = event.pathParameters.id;
-  const product = products.find(x => x.id.toString() === productId.toString());
+
+  const productData = await docClient.get({
+    TableName : process.env.PRODUCTS_DB_NAME,
+    Key: {
+      id: productId,
+    },
+  })
+    .promise();
+
+  const stockData = await docClient.get({
+    TableName : process.env.STOCKS_DB_NAME,
+    Key: {
+      product_id: productId,
+    },
+  })
+    .promise();
+
+  const responseData = {
+    ...productData.Item,
+    count: stockData.Item.count
+  }
   return {
     statusCode: 200,
     headers: {
       "content-type":"application/json",
     },
-    body: JSON.stringify(product)
+    body: JSON.stringify(responseData)
+  };
+};
+
+module.exports.createProduct = async (event) => {
+  const productBodyParams = JSON.parse(event.body);
+  const productUuid = AWS.util.uuid.v4();
+
+  const newProductParams = {
+    TableName: process.env.PRODUCTS_DB_NAME,
+    Item: {
+      id: productUuid,
+      price: productBodyParams.price.toString(),
+      title: productBodyParams.title,
+      description: productBodyParams.description,
+    },
+  };
+  await docClient.put(newProductParams).promise();
+
+  const newCountParams = {
+    TableName: process.env.STOCKS_DB_NAME,
+    Item: {
+      product_id: productUuid,
+      count: productBodyParams.count
+    },
+  };
+  await docClient.put(newCountParams).promise();
+  return {
+    statusCode: 200
   };
 };

--- a/productService/serverless.yml
+++ b/productService/serverless.yml
@@ -1,24 +1,9 @@
-# Welcome to Serverless!
-#
-# This file is the main config file for your service.
-# It's very minimal at this point and uses default values.
-# You can always add more config options for more control.
-# We've included some commented out config examples here.
-# Just uncomment any of them to get that config option.
-#
-# For full config options, check the docs:
-#    docs.serverless.com
-#
-# Happy Coding!
-
 service: productservice
-# app and org for use with dashboard.serverless.com
-#app: your-app-name
-#org: your-org-name
-
-# You can pin your service to only deploy with a specific Serverless version
-# Check out our docs for more details
 frameworkVersion: '3'
+
+custom:
+  productsDbName: cloudX_products
+  stocksDbName: cloudX_stocks
 
 provider:
   name: aws
@@ -27,37 +12,22 @@ provider:
   region: eu-west-1
   httpApi:
     cors: true
+  environment:
+    PRODUCTS_DB_NAME: ${self:custom.productsDbName}
+    STOCKS_DB_NAME: ${self:custom.stocksDbName}
 
+  # give access to DBs to everybody
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+      Resource:
+        - { "Fn::GetAtt": ["Products", "Arn"] }
+        - { "Fn::GetAtt": ["Stocks", "Arn"] }
 
-# you can add statements to the Lambda function's IAM Role here
-#  iam:
-#    role:
-#      statements:
-#        - Effect: "Allow"
-#          Action:
-#            - "s3:ListBucket"
-#          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
-#        - Effect: "Allow"
-#          Action:
-#            - "s3:PutObject"
-#          Resource:
-#            Fn::Join:
-#              - ""
-#              - - "arn:aws:s3:::"
-#                - "Ref" : "ServerlessDeploymentBucket"
-#                - "/*"
-
-# you can define service wide environment variables here
-#  environment:
-#    variable1: value1
-
-# you can add packaging information here
-#package:
-#  patterns:
-#    - '!exclude-me.js'
-#    - '!exclude-me-dir/**'
-#    - include-me.js
-#    - include-me-dir/**
 
 functions:
   getProductsList:
@@ -70,58 +40,41 @@ functions:
     handler: handler.getProductsById
     events:
       - httpApi:
-          path: /getProductsById/{id}
+          path: /products/{id}
           method: get
+  createProduct:
+    handler: handler.createProduct
+    events:
+      - httpApi:
+          path: /products
+          method: post
 
+resources:
+  Resources:
+    Products:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.productsDbName}
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
 
-#    The following are a few example events you can configure
-#    NOTE: Please make sure to change your handler code to work with those events
-#    Check the event documentation for details
-#    events:
-#      - httpApi:
-#          path: /users/create
-#          method: get
-#      - websocket: $connect
-#      - s3: ${env:BUCKET}
-#      - schedule: rate(10 minutes)
-#      - sns: greeter-topic
-#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
-#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
-#      - iot:
-#          sql: "SELECT * FROM 'some_topic'"
-#      - cloudwatchEvent:
-#          event:
-#            source:
-#              - "aws.ec2"
-#            detail-type:
-#              - "EC2 Instance State-change Notification"
-#            detail:
-#              state:
-#                - pending
-#      - cloudwatchLog: '/aws/lambda/hello'
-#      - cognitoUserPool:
-#          pool: MyUserPool
-#          trigger: PreSignUp
-#      - alb:
-#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
-#          priority: 1
-#          conditions:
-#            host: example.com
-#            path: /hello
-
-#    Define function environment variables here
-#    environment:
-#      variable2: value2
-
-# you can add CloudFormation resource templates here
-#resources:
-#  Resources:
-#    NewResource:
-#      Type: AWS::S3::Bucket
-#      Properties:
-#        BucketName: my-new-bucket
-#  Outputs:
-#     NewOutput:
-#       Description: "Description for the output"
-#       Value: "Some output value"
+    Stocks:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.stocksDbName}
+        AttributeDefinitions:
+          - AttributeName: product_id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: product_id
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1


### PR DESCRIPTION
Tasks 4.1, 4.2, 4.3 and 4.4 DONE.

- add Dynamo DB tables via serverless.yml
- update the lambda functions `getProductsList` and `getProductById` to return products from DB
- add a new lambda function `createProduct` to put new products in DB via a POST request
- add a js utility to create products in DB from a local JSON file
- changes for FE app not needed

Lambda API: https://m103n0bqv2.execute-api.eu-west-1.amazonaws.com/
Deployed FE app: https://dg1rk4q1fwg0t.cloudfront.net/