### PR TITLE
task 5: add lambda functions for import

### DIFF
--- a/importService/.gitignore
+++ b/importService/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/importService/handler.js
+++ b/importService/handler.js
@@ -1,0 +1,11 @@
+'use strict';
+const {importProductsFile} = require('./importProductsFile');
+const {importFileParser} = require("./importFileParser");
+
+module.exports.importProductsFile = async (event) => {
+  return importProductsFile(event);
+};
+
+module.exports.importFileParser = async (event) => {
+  await importFileParser(event);
+}

--- a/importService/importFileParser.js
+++ b/importService/importFileParser.js
@@ -1,0 +1,30 @@
+const AWS = require('aws-sdk');
+const csv = require('csv-parser')
+const s3 = new AWS.S3();
+
+module.exports.importFileParser = (event) => {
+  const params = {
+    Bucket: event.Records[0].s3.bucket.name,
+    Key: event.Records[0].s3.object.key
+  }
+  const results = [];
+  const s3Stream = s3.getObject(params).createReadStream();
+
+  const resultPromise = new Promise((res, rej) => {
+    try{
+      s3Stream
+        .pipe(csv())
+        .on('data', (data) => results.push(data))
+        .on('end', () => {
+          console.log('Uploaded CSV content:');
+          console.log(results);
+          res();
+        });
+    } catch(err){
+      console.log('Error while reading imported file');
+      console.error(err);
+      rej(err);
+    }
+  })
+  return resultPromise;
+}

--- a/importService/importProductsFile.js
+++ b/importService/importProductsFile.js
@@ -1,0 +1,17 @@
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+
+module.exports.importProductsFile = async (event) => {
+  const fileName = event.queryStringParameters.name || 'defaultFileName';
+  const key = `uploaded/${fileName}`;
+  const params = {
+    Bucket: process.env.IMPORT_BUCKET_NAME,
+    Key: key,
+    ContentType: 'text/csv',
+  };
+  const link = await s3.getSignedUrlPromise('putObject', params);
+  return {
+    statusCode: 200,
+    body: link
+  };
+}

--- a/importService/package-lock.json
+++ b/importService/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "importService",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "csv-parser": "^3.0.0"
+      }
+    },
+    "node_modules/csv-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
+      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "dependencies": {
+    "csv-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
+      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+    }
+  }
+}

--- a/importService/package.json
+++ b/importService/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "csv-parser": "^3.0.0"
+  }
+}

--- a/importService/serverless.yml
+++ b/importService/serverless.yml
@@ -1,0 +1,137 @@
+service: importservice
+frameworkVersion: '3'
+
+custom:
+  importBucketName: cloudx-import-n19
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+  httpApi:
+    cors: true
+  environment:
+    IMPORT_BUCKET_NAME: ${self:custom.importBucketName}
+
+  # give access to DBs to Import Bucket
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - s3:ListBucket
+      Resource:
+        - "arn:aws:s3:::cloudx-import-n19"
+    - Effect: "Allow"
+      Action:
+        - s3:*
+      Resource:
+        - "arn:aws:s3:::cloudx-import-n19/*"
+
+functions:
+  importProductsFile:
+    handler: handler.importProductsFile
+    events:
+      - httpApi:
+          path: /import
+          method: get
+
+  importFileParser:
+    handler: handler.importFileParser
+    events:
+      - s3:
+          bucket: ${self:custom.importBucketName}
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: uploaded/
+          # Set to 'true' when using an existing bucket
+          # Else the bucket will be automatically created
+#          existing: true
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+# you can add statements to the Lambda function's IAM Role here
+#  iam:
+#    role:
+#      statements:
+#        - Effect: "Allow"
+#          Action:
+#            - "s3:ListBucket"
+#          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#        - Effect: "Allow"
+#          Action:
+#            - "s3:PutObject"
+#          Resource:
+#            Fn::Join:
+#              - ""
+#              - - "arn:aws:s3:::"
+#                - "Ref" : "ServerlessDeploymentBucket"
+#                - "/*"
+
+# you can define service wide environment variables here
+#  environment:
+#    variable1: value1
+
+# you can add packaging information here
+#package:
+#  patterns:
+#    - '!exclude-me.js'
+#    - '!exclude-me-dir/**'
+#    - include-me.js
+#    - include-me-dir/**
+
+#functions:
+#  hello:
+#    handler: handler.hello
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - httpApi:
+#          path: /users/create
+#          method: get
+#      - websocket: $connect
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
+#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+#      - alb:
+#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
+#          priority: 1
+#          conditions:
+#            host: example.com
+#            path: /hello
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+#resources:
+#  Resources:
+#    NewResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: my-new-bucket
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"


### PR DESCRIPTION
Tasks 5.1, 5.2, 5.3 and 5.4 DONE.

- create a new service `importservice` with lambda functions `importProductsFile` and `importFileParser`
- `serverless.yml` for the new service contains settings for lambda function, s3 bucket, and permissions
- `importProductsFile` returns signed URLs for file uploading
- `importFileParser` is triggered by file uploading. The function reads a file via a stream and logs content in CloudWatch console

FE repo PR (provide import URL) https://github.com/ungear/shop-angular-cloudfront/pull/3

Deployed app link https://dg1rk4q1fwg0t.cloudfront.net/